### PR TITLE
feat: add force reveal button for owner to close voting early

### DIFF
--- a/src/components/ForceRevealButton.module.css
+++ b/src/components/ForceRevealButton.module.css
@@ -1,0 +1,29 @@
+.button {
+  padding: 12px 24px;
+  background-color: #ffc107;
+  color: #000;
+  border: none;
+  border-radius: 8px;
+  font-size: 16px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.2s;
+  width: 100%;
+  margin-top: 20px;
+}
+
+.button:hover:not(:disabled) {
+  background-color: #ffb300;
+  transform: translateY(-2px);
+  box-shadow: 0 4px 8px rgba(255, 193, 7, 0.3);
+}
+
+.button:active:not(:disabled) {
+  transform: translateY(0);
+}
+
+.button:disabled {
+  background-color: #e0e0e0;
+  color: #9e9e9e;
+  cursor: not-allowed;
+}

--- a/src/components/ForceRevealButton.tsx
+++ b/src/components/ForceRevealButton.tsx
@@ -1,0 +1,39 @@
+import { useState } from 'react';
+import styles from './ForceRevealButton.module.css';
+
+interface ForceRevealButtonProps {
+  onForceReveal: () => Promise<void>;
+}
+
+// Force reveal button for owner to close voting early
+export default function ForceRevealButton({ onForceReveal }: ForceRevealButtonProps) {
+  const [revealing, setRevealing] = useState(false);
+
+  const handleClick = async () => {
+    if (revealing) return;
+    
+    if (!window.confirm('投票を締め切り、現在の選択のみで結果を表示しますか？')) {
+      return;
+    }
+    
+    try {
+      setRevealing(true);
+      await onForceReveal();
+    } catch (error) {
+      console.error('Failed to force reveal:', error);
+      alert('締め切りに失敗しました。もう一度お試しください。');
+    } finally {
+      setRevealing(false);
+    }
+  };
+
+  return (
+    <button
+      className={styles.button}
+      onClick={handleClick}
+      disabled={revealing}
+    >
+      {revealing ? '締め切り中...' : '⏰ 投票を締め切る'}
+    </button>
+  );
+}


### PR DESCRIPTION
## 概要

オーナーが投票を強制的に締め切る機能を追加しました。

## 背景・課題

Planning Pokerの運用中、以下のような問題が発生していました：

- 参加者が離脱したり、選択せずに放置すると、ラウンドが永遠に完了しない
- 全員の選択を待つ間、他の参加者が待たされる
- 現在の選択だけで結果を見たい場合でも、締め切る手段がなかった

## 変更内容

### 新規追加ファイル

- `src/components/ForceRevealButton.tsx`: 投票締め切りボタンコンポーネント
- `src/components/ForceRevealButton.module.css`: ボタンのスタイル（黄色の警告色）

### 変更ファイル

- `src/components/RoomPage.tsx`:
  - `handleForceReveal()` 関数を追加
  - Owner専用で `selecting` 状態時にボタンを表示
  - 現在の選択のみで統計計算し、`revealed` 状態に遷移

## 機能詳細

### UI

- **表示条件**: Ownerのみ、ラウンドが `selecting` 状態の時
- **配置**: CardSelectorの直下
- **デザイン**: 黄色背景で「⏰ 投票を締め切る」
- **確認ダイアログ**: 誤操作防止のため、クリック時に確認

### 動作フロー

1. Ownerが「投票を締め切る」ボタンをクリック
2. 確認ダイアログ表示: 「投票を締め切り、現在の選択のみで結果を表示しますか？」
3. OKをクリック
4. 現在選択済みのカードで統計計算 (`calculate_round_statistics`)
5. ラウンド状態を `revealed` に更新
6. 結果画面に遷移

### セキュリティ

- UIレベルでOwnerのみ表示
- 既存のRLS（Row Level Security）ポリシーにより、Owner以外はラウンド状態を更新できない

## テスト方法

1. ローカルで開発サーバーを起動
2. 新規ルームを作成（自分がOwner）
3. ラウンドを開始
4. 自分だけカードを選択（他の参加者は選択しない状態を想定）
5. 「⏰ 投票を締め切る」ボタンが表示されることを確認
6. ボタンをクリック→確認ダイアログ→OK
7. 結果画面に遷移し、選択済みのカードのみで統計が表示されることを確認

## 注意点

- 一度締め切ると取り消せません（新しいラウンドを開始する必要があります）
- 選択していない参加者のカードは「?」と表示されたまま結果に含まれません
- 統計計算は選択済みのカードのみで行われます（例: 3人中1人だけ選択済みの場合、1人分の統計）

## 関連Issue

ユーザーからのフィードバック: 「ユーザーの離脱ができないのでオーナーが強制的に回答を締め切る実装したい」